### PR TITLE
OpenWrt: verify PKG_HASH

### DIFF
--- a/openwrt/aliyundrive-webdav/Makefile
+++ b/openwrt/aliyundrive-webdav/Makefile
@@ -43,7 +43,20 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/aliyundrive-webdav
 endef
 
+define Download/sha256sum
+	FILE:=$(PKG_SOURCE).sha256
+	URL_FILE:=$(FILE)
+	URL:=$(PKG_SOURCE_URL)
+	HASH:=skip
+endef
+$(eval $(call Download,sha256sum))
+
 define Build/Prepare
+	mv $(DL_DIR)/$(PKG_SOURCE).sha256 .
+	cp $(DL_DIR)/$(PKG_SOURCE) .
+	shasum -a 256 -c $(PKG_SOURCE).sha256
+	rm $(PKG_SOURCE).sha256 $(PKG_SOURCE)
+
 	tar -C $(PKG_BUILD_DIR)/ -zxf $(DL_DIR)/$(PKG_SOURCE)
 endef
 


### PR DESCRIPTION
虽然最安全的方式是给每个下载的文件定义 PKG_HASH，但对于目前这种不同平台下载不同的二进制包的方式来说维护成本过高，类似 https://github.com/immortalwrt/packages/blob/master/net/shadowsocks-rust/Makefile 的做法更适合下游自行打包使用。

折中方案：

1. CI 在打包二进制包的同时计算并存储 sha256 hash 发布到 GitHub Releases 中
2. OpenWrt 打包是下载 sha256 hash 文件在 Prepare 过程中调用 shasum 自行校验

从安全角度来说，下载是走的 https 被中间人攻击的概率较低，即便发生中间人攻击也需要同时篡改两个文件才能保证构建成功，攻击成本和难度提升；从文件完整性角度来说，目前这种做法可以保证，任何一个文件传输过程受损，shasum 校验都不会成功导致构建失败。

cc @Beginner-Go 