### PR TITLE
feat: Support macOS Finder uploader

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -482,7 +482,7 @@ impl AliyunDavFile {
     }
 
     async fn prepare_for_upload(&mut self) -> Result<(), FsError> {
-        if self.file.name.clone().as_bytes().starts_with(b"._") || self.file.size == 0 {
+        if self.file.name.starts_with("._") || self.file.size == 0 {
             return Ok(());
         }
         if self.upload_state.chunk_count == 0 {
@@ -526,7 +526,7 @@ impl AliyunDavFile {
     }
 
     async fn maybe_upload_chunk(&mut self, remaining: bool) -> Result<(), FsError> {
-        if self.file.name.clone().as_bytes().starts_with(b"._") {
+        if self.file.name.starts_with("._") {
             return Ok(());
         }
         let chunk_size = if remaining {


### PR DESCRIPTION
开发者你好，我尝试修复了一下macOS的Finder上传的功能，现在可以上传文件了。
另外https://github.com/messense/aliyundrive-webdav/issues/73 反馈的0KB文件可能与write_byte没有修改file.size并且直接调用prepare_for_upload有关。
写完这个我在想 `write_buf` 是否也需要修改 `self.file.size`？
