### PR TITLE
feat: add command to support terminal CLI to get refresh_token

### DIFF
--- a/src/login/model.rs
+++ b/src/login/model.rs
@@ -47,6 +47,10 @@ impl GeneratorQrCodeResult {
         }
         String::new()
     }
+
+    pub fn get_content_data(self) -> Option<GeneratorQrCodeContentData> {
+        self.content?.data
+    }
 }
 
 impl Ok for GeneratorQrCodeResult {
@@ -79,7 +83,7 @@ impl GeneratorQrCodeContent {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GeneratorQrCodeContentData {
     #[serde(rename = "t")]
     #[serde(default)]
@@ -200,6 +204,12 @@ pub struct QueryQrCodeContentData {
 pub struct QueryQrCodeCkForm {
     t: i64,
     ck: String,
+}
+
+impl QueryQrCodeCkForm {
+    pub fn new(t: i64, ck: String) -> Self {
+        Self { t, ck }
+    }
 }
 
 impl From<GeneratorQrCodeResult> for QueryQrCodeCkForm {


### PR DESCRIPTION
- 加个终端登陆获取app refresh_token命令，方便openwrt、docker用户获取refresh_token来使用。
- 还有一个是提供一个返回生成二维码内容和查询扫码参数的命令，根据参数查询扫码状态。这个是想给openwrt luci或梅林固件调用查询，后面看看有没有人贡献下openwrt luci-app 页面，直接显示二维码来扫码登陆。

- examples
```shell
# 登陆返回refresh_token
aliyundrive-webdav qr qr-login
# 返回需要生成二维码的content，以及查询参数t，ck
aliyundrive-webdav qr qr-generate

# 查询登陆结果获取refresh_token
aliyundrive-webdav qr-query --t 1111111111 --ck ssssssssss
```