### PR TITLE
添加 302 重定向选项

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,9 @@ dependencies = [
 
 [[package]]
 name = "dav-server"
-version = "0.4.0"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7e01b6133ae736306aa7e19ccc4b3333aac8afe0720e286ceb84a81b0555db"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,8 +467,6 @@ dependencies = [
 [[package]]
 name = "dav-server"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd54eb9b5800e91cca178eda3f11e4cf544206b8153f490f60065ee5714708"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.59"
 bytes = "1.2.1"
 clap = { version = "3.2.2", features = ["derive", "env", "wrap_help", "unstable-v4"] }
 dashmap = "5.3.2"
-dav-server = { version = "0.4.0", default-features = false, features = ["hyper"] }
+dav-server = { version = "0.4.0", default-features = false, features = ["hyper"], path="../dav-server-rs" }
 dirs = "4.0.0"
 futures-util = "0.3"
 headers = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.59"
 bytes = "1.2.1"
 clap = { version = "3.2.2", features = ["derive", "env", "wrap_help", "unstable-v4"] }
 dashmap = "5.3.2"
-dav-server = { version = "0.4.0", default-features = false, features = ["hyper"], path="../dav-server-rs" }
+dav-server = { version = "0.5.0", default-features = false, features = ["hyper"] }
 dirs = "4.0.0"
 futures-util = "0.3"
 headers = "0.3.6"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > 🚀 Help me to become a full-time open-source developer by [sponsoring me on GitHub](https://github.com/sponsors/messense)
 
 阿里云盘 WebDAV 服务，主要使用场景为配合支持 WebDAV 协议的客户端 App 如 [Infuse](https://firecore.com/infuse)、[nPlayer](https://nplayer.com)
-等实现在电视上直接观看云盘视频内容， 支持上传文件，但受限于 WebDAV 协议不支持文件秒传。
+等实现在电视上直接观看云盘视频内容， 支持客户端 App 直接从阿里云盘获取文件播放而不经过运行本应用的服务器中转, 支持上传文件，但受限于 WebDAV 协议不支持文件秒传。
 
 如果你使用 Emby 或者 Jellyfin，也可以试试 [aliyundrive-fuse](https://github.com/messense/aliyundrive-fuse) 项目。
 
@@ -157,6 +157,7 @@ OPTIONS:
     -p, --port <PORT>                                Listen port [env: PORT=] [default: 8080]
         --prefer-http-download                       Prefer downloading using HTTP protocol
     -r, --refresh-token <REFRESH_TOKEN>              Aliyun drive refresh token [env: REFRESH_TOKEN=]
+    -R, --redirect                                   Dose GET on a file return 302 redirect
         --read-only                                  Enable read only mode
         --root <ROOT>                                Root directory path [default: /]
     -S, --read-buffer-size <READ_BUFFER_SIZE>        Read/download buffer size in bytes, defaults to 10MB [default: 10485760]
@@ -182,6 +183,10 @@ SUBCOMMANDS:
 > **Note**
 > 
 > 注意：启用 `--skip-upload-same-size` 选项虽然能加速上传但可能会导致修改过的同样大小的文件不会被上传
+
+> **Note**
+>
+>注意：启用 `-R` 选项可以让 WebDAV 客户端直接从阿里云获取文件而不经过中转，但受限于阿里云盘的 Referer 限制，不能使用从网页获取的 refresh_token
 
 ### 获取 refresh_token
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ OPTIONS:
     -p, --port <PORT>                                Listen port [env: PORT=] [default: 8080]
         --prefer-http-download                       Prefer downloading using HTTP protocol
     -r, --refresh-token <REFRESH_TOKEN>              Aliyun drive refresh token [env: REFRESH_TOKEN=]
-    -R, --redirect                                   Dose GET on a file return 302 redirect
+    -R, --redirect                                   Does GET on a file return 302 redirect
         --read-only                                  Enable read only mode
         --root <ROOT>                                Root directory path [default: /]
     -S, --read-buffer-size <READ_BUFFER_SIZE>        Read/download buffer size in bytes, defaults to 10MB [default: 10485760]

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ OPTIONS:
     -h, --help                                       Print help information
         --host <HOST>                                Listen host [env: HOST=] [default: 0.0.0.0]
     -I, --auto-index                                 Automatically generate index.html
+        --no-redirect                                Disable 302 redirect when using app refresh token
         --no-self-upgrade                            Disable self auto upgrade
         --no-trash                                   Delete file permanently instead of trashing it
     -p, --port <PORT>                                Listen port [env: PORT=] [default: 8080]
         --prefer-http-download                       Prefer downloading using HTTP protocol
     -r, --refresh-token <REFRESH_TOKEN>              Aliyun drive refresh token [env: REFRESH_TOKEN=]
-    -R, --redirect                                   Does GET on a file return 302 redirect
         --read-only                                  Enable read only mode
         --root <ROOT>                                Root directory path [default: /]
     -S, --read-buffer-size <READ_BUFFER_SIZE>        Read/download buffer size in bytes, defaults to 10MB [default: 10485760]
@@ -186,7 +186,7 @@ SUBCOMMANDS:
 
 > **Note**
 >
->注意：启用 `-R` 选项可以让 WebDAV 客户端直接从阿里云获取文件而不经过中转，但受限于阿里云盘的 Referer 限制，不能使用从网页获取的 refresh_token
+>注意：使用 App refresh token 时，WebDAV 客户端请求文件会默认返回 302 重定向而不经过中转。如需中转请启用 `--no-redirect` 选项。
 
 ### 获取 refresh_token
 

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -41,7 +41,7 @@ pub struct DriveConfig {
     pub client_type: ClientType,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ClientType {
     Web,
     App,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Opt {
     /// Automatically generate index.html
     #[clap(short = 'I', long)]
     auto_index: bool,
-    /// Does GET on a file return 302 redirect.
+    /// Disable 302 redirect when using app refresh token
     #[clap(long)]
     no_redirect: bool,
     /// Read/download buffer size in bytes, defaults to 10MB

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,9 @@ struct Opt {
     /// Automatically generate index.html
     #[clap(short = 'I', long)]
     auto_index: bool,
+    /// Dose GET on a file return 302 redirect.
+    #[clap(short = 'R', long)]
+    redirect: bool,
     /// Read/download buffer size in bytes, defaults to 10MB
     #[clap(short = 'S', long, default_value = "10485760")]
     read_buffer_size: usize,
@@ -275,7 +278,8 @@ async fn main() -> anyhow::Result<()> {
         .filesystem(Box::new(fs))
         .locksystem(MemLs::new())
         .read_buf_size(opt.read_buffer_size)
-        .autoindex(opt.auto_index);
+        .autoindex(opt.auto_index)
+        .redirect(opt.redirect);
     if let Some(prefix) = opt.strip_prefix {
         dav_server_builder = dav_server_builder.strip_prefix(prefix);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Opt {
     /// Automatically generate index.html
     #[clap(short = 'I', long)]
     auto_index: bool,
-    /// Dose GET on a file return 302 redirect.
+    /// Does GET on a file return 302 redirect.
     #[clap(short = 'R', long)]
     redirect: bool,
     /// Read/download buffer size in bytes, defaults to 10MB

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,8 @@ struct Opt {
     #[clap(short = 'I', long)]
     auto_index: bool,
     /// Does GET on a file return 302 redirect.
-    #[clap(short = 'R', long)]
-    redirect: bool,
+    #[clap(long)]
+    no_redirect: bool,
     /// Read/download buffer size in bytes, defaults to 10MB
     #[clap(short = 'S', long, default_value = "10485760")]
     read_buffer_size: usize,
@@ -279,7 +279,7 @@ async fn main() -> anyhow::Result<()> {
         .locksystem(MemLs::new())
         .read_buf_size(opt.read_buffer_size)
         .autoindex(opt.auto_index)
-        .redirect(opt.redirect);
+        .redirect(client_type == ClientType::App && !opt.no_redirect);
     if let Some(prefix) = opt.strip_prefix {
         dav_server_builder = dav_server_builder.strip_prefix(prefix);
     }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -837,7 +837,11 @@ impl DavFile for AliyunDavFile {
                 let res = self.get_download_url().await?;
                 res.url
             };
-            Ok(Some(download_url))
+            if !download_url.is_empty() {
+                Ok(Some(download_url))
+            } else {
+                Ok(None)
+            }
         }
         .boxed()
     }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -2,10 +2,8 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use url::Url;
 
 use anyhow::Result;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -822,7 +820,7 @@ impl DavFile for AliyunDavFile {
         .boxed()
     }
 
-    fn redirect_url(&mut self) -> FsFuture<Url> {
+    fn redirect_url(&mut self) -> FsFuture<Option<String>> {
         debug!(file_id = %self.file.id, file_name = %self.file.name, "file: redirect_url");
         async move {
             if self.file.id.is_empty() {
@@ -839,8 +837,7 @@ impl DavFile for AliyunDavFile {
                 let res = self.get_download_url().await?;
                 res.url
             };
-            let download_url = Url::from_str(&download_url).map_err(|_| FsError::GeneralFailure)?;
-            Ok(download_url)
+            Ok(Some(download_url))
         }
         .boxed()
     }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use url::Url;
 
 use anyhow::Result;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -820,7 +822,7 @@ impl DavFile for AliyunDavFile {
         .boxed()
     }
 
-    fn redirect_url(&mut self) -> FsFuture<String> {
+    fn redirect_url(&mut self) -> FsFuture<Url> {
         debug!(file_id = %self.file.id, file_name = %self.file.name, "file: redirect_url");
         async move {
             if self.file.id.is_empty() {
@@ -837,6 +839,7 @@ impl DavFile for AliyunDavFile {
                 let res = self.get_download_url().await?;
                 res.url
             };
+            let download_url = Url::from_str(&download_url).map_err(|_| FsError::GeneralFailure)?;
             Ok(download_url)
         }
         .boxed()

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -838,11 +838,10 @@ impl DavFile for AliyunDavFile {
                 res.url
             };
             Ok(download_url)
-
         }
         .boxed()
     }
-        
+
     fn write_buf(&'_ mut self, buf: Box<dyn Buf + Send>) -> FsFuture<'_, ()> {
         debug!(file_id = %self.file.id, file_name = %self.file.name, "file: write_buf");
         async move {


### PR DESCRIPTION
支持 WebDAV 客户端 App 直接从阿里云盘获取文件而不经过中转。

可以节省服务器流量。

已经在 iPad 上 Infuse 和 Fileball 以及 Archlinux Dolphin 文件管理器测试，可以正常播放视频、查看文件。