### PR TITLE
下载链接包含 `x-oss-additional-headers=referer` 时需要中转

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -837,11 +837,14 @@ impl DavFile for AliyunDavFile {
                 let res = self.get_download_url().await?;
                 res.url
             };
+
             if !download_url.is_empty() {
-                Ok(Some(download_url))
-            } else {
-                Ok(None)
+                self.file.url = Some(download_url.clone());
+                if !download_url.contains("x-oss-additional-headers=referer") {
+                    return Ok(Some(download_url));
+                }
             }
+            Ok(None)
         }
         .boxed()
     }


### PR DESCRIPTION
Fixes https://github.com/messense/aliyundrive-webdav/pull/557#issuecomment-1216138006
Fixes #561

@zhudan 可以确认下下载链接是不是包含了 `x-oss-additional-headers=referer`

cc @sihuan 