### PR TITLE
fix: Fix the font cannot be displayed under the white background

### DIFF
--- a/openwrt/luci-app-aliyundrive-webdav/luasrc/view/aliyundrive-webdav/aliyundrive-webdav_qrcode.htm
+++ b/openwrt/luci-app-aliyundrive-webdav/luasrc/view/aliyundrive-webdav/aliyundrive-webdav_qrcode.htm
@@ -9,6 +9,7 @@
         background: rgba(255, 255, 255, .8);
     }
     #mask-box #code-box {
+        color: #000000;
         width: 288px;
         height: 325px;
         border: 1px solid #585858;


### PR DESCRIPTION
> 修复暗黑主题二维码扫描白背景字体显示不清晰问题

- 前
<img width="613" alt="image" src="https://user-images.githubusercontent.com/51810656/212814023-cf9195e3-5516-4d2c-9ddd-1db6f3c0c30a.png">
<img width="557" alt="image" src="https://user-images.githubusercontent.com/51810656/212814222-17576905-7076-454a-b940-73a90759a74d.png">

- 后
<img width="509" alt="image" src="https://user-images.githubusercontent.com/51810656/212814096-510b50d1-664d-4ab4-b9d0-2c465db44e37.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/51810656/212814345-7f131afd-75e3-493a-8523-40f83d79b4f0.png">



