### PR TITLE
Update qrcodejs cdn

### DIFF
--- a/openwrt/luci-app-aliyundrive-webdav/luasrc/view/aliyundrive-webdav/aliyundrive-webdav_qrcode.htm
+++ b/openwrt/luci-app-aliyundrive-webdav/luasrc/view/aliyundrive-webdav/aliyundrive-webdav_qrcode.htm
@@ -1,5 +1,5 @@
 <%+cbi/valueheader%>
-<script src="https://cdn.jsdelivr.net/npm/qrcode_js@1.0.0/qrcode.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <style>
     #mask-box {
         z-index: 1000;


### PR DESCRIPTION
jsdelivr.net cdn好像国内歇b了，导致经常加载卡住，测试换了：https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js
稳了点
![image](https://user-images.githubusercontent.com/51810656/233110679-81f9c5b8-4b5c-4206-8f38-68e0f67c3898.png)
