### PR TITLE
Fix tokio asynchronous multi-thread log unknown time

### DIFF
--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -356,9 +356,10 @@ impl AliyunDrive {
             .await
             .and_then(|res| res.context("expect response"))?;
         let drive_id = match drive_type {
-            Some(DriveType::Resource) => {
-                res.resource_drive_id.context("resource drive not found")?
-            }
+            Some(DriveType::Resource) => res.resource_drive_id.unwrap_or_else(|| {
+                warn!("resource drive not found, use default drive instead");
+                res.default_drive_id
+            }),
             Some(DriveType::Backup) => res.backup_drive_id.unwrap_or_else(|| {
                 warn!("backup drive not found, use default drive instead");
                 res.default_drive_id

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     tracing_subscriber::fmt()
-        .with_timer(tracing_subscriber::fmt::time::OffsetTime::local_rfc_3339()?)
+        .with_timer(tracing_subscriber::fmt::time::time())
         .init();
 
     let workdir = opt

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     tracing_subscriber::fmt()
-        .with_timer(tracing_subscriber::fmt::time::LocalTime::rfc_3339())
+        .with_timer(tracing_subscriber::fmt::time::OffsetTime::local_rfc_3339()?)
         .init();
 
     let workdir = opt


### PR DESCRIPTION
修复tokio异步多线程日志时间显示：unknown time
```rust
#[cfg(feature = "local-time")]
impl OffsetTime<well_known::Rfc3339> {
    /// Returns a formatter that formats the current time using the [local time offset] in the [RFC
    /// 3339] format (a subset of the [ISO 8601] timestamp format).
    ///
    /// Returns an error if the local time offset cannot be determined. This typically occurs in
    /// multithreaded programs. To avoid this problem, initialize `OffsetTime` before forking
    /// threads. When using Tokio, this means initializing `OffsetTime` before the Tokio runtime.
    ///
    /// # Examples
    ///
    /// ```
    /// use tracing_subscriber::fmt::{self, time};
    ///
    /// let collector = tracing_subscriber::fmt()
    ///     .with_timer(time::OffsetTime::local_rfc_3339().expect("could not get local offset!"));
    /// # drop(collector);
    /// ```
    ///
    /// Using `OffsetTime` with Tokio:
    ///
    /// ```
    /// use tracing_subscriber::fmt::time::OffsetTime;
    ///
    /// #[tokio::main]
    /// async fn run() {
    ///     tracing::info!("runtime initialized");
    ///
    ///     // At this point the Tokio runtime is initialized, and we can use both Tokio and Tracing
    ///     // normally.
    /// }
    ///
    /// fn main() {
    ///     // Because we need to get the local offset before Tokio spawns any threads, our `main`
    ///     // function cannot use `tokio::main`.
    ///     tracing_subscriber::fmt()
    ///         .with_timer(OffsetTime::local_rfc_3339().expect("could not get local time offset"))
    ///         .init();
    ///
    ///     // Even though `run` is written as an `async fn`, because we used `tokio::main` on it
    ///     // we can call it as a synchronous function.
    ///     run();
    /// }
    /// ```
    ///
    /// [local time offset]: time::UtcOffset::current_local_offset
    /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
    /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
    pub fn local_rfc_3339() -> Result<Self, time::error::IndeterminateOffset> {
        Ok(Self::new(
            UtcOffset::current_local_offset()?,
            well_known::Rfc3339,
        ))
    }
}
```