### PR TITLE
Add WEBDAV_ROOT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Options:
       --root <ROOT>
           Root directory path
 
+          [env: WEBDAV_ROOT=]
           [default: /]
 
   -w, --workdir <WORKDIR>

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ struct Opt {
     #[arg(long, default_value = "600")]
     cache_ttl: u64,
     /// Root directory path
-    #[arg(long, default_value = "/")]
+    #[arg(long, env = "WEBDAV_ROOT", default_value = "/")]
     root: String,
     /// Working directory, refresh_token will be stored in there if specified
     #[arg(short = 'w', long)]


### PR DESCRIPTION
添加 root 环境变量 WEBDAV_ROOT，方便在 docker 中使用时，可以直接修改