### PR TITLE
Fix RUST_LOG not working

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use dav_server::{memls::MemLs, DavHandler};
 use futures_util::stream::StreamExt;
 use self_update::cargo_crate_version;
 use tracing::{debug, info, warn};
+use tracing_subscriber::EnvFilter;
 #[cfg(unix)]
 use {signal_hook::consts::signal::*, signal_hook_tokio::Signals};
 
@@ -142,6 +143,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
         .with_timer(tracing_subscriber::fmt::time::time())
         .init();
 


### PR DESCRIPTION
旧方法`tracing_subscriber::fmt::init()`会处理 RUST_LOG 环境变量，但新的`tracing_subscriber::fmt().init()`默认不处理，导致没法通过 RUST_LOG 修改日志级别