### PR TITLE
refactor(backend): allow to warp the token

### DIFF
--- a/backend/refresh_token.py
+++ b/backend/refresh_token.py
@@ -2,6 +2,7 @@ import asyncio
 
 import httpx
 import streamlit as st
+from streamlit_extras.stylable_container import stylable_container
 
 
 session = httpx.AsyncClient()
@@ -81,7 +82,11 @@ async def main():
 
             if refresh_token:
                 st.success("refresh token 获取成功", icon="✅")
-                st.code(refresh_token, language=None)
+                with stylable_container(
+                    "codeblock",
+                    "code { white-space: normal !important; overflow-wrap: anywhere; }",
+                ):
+                    st.code(refresh_token, language=None)
 
     with authcode_tab:
         with st.form("authCode"):
@@ -91,7 +96,11 @@ async def main():
                 try:
                     refresh_token = await get_refresh_token(code)
                     st.success("refresh token 获取成功", icon="✅")
-                    st.code(refresh_token, language=None)
+                    with stylable_container(
+                        "codeblock",
+                        "code { white-space: normal !important; overflow-wrap: anywhere; }",
+                    ):
+                        st.code(refresh_token, language=None)
                 except KeyError:
                     st.error("无效的 authCode, 请重新获取", icon="🚨")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.93.0
 httpx
-uvicorn[standard]
 streamlit_extras
+uvicorn[standard]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.93.0
 httpx
 uvicorn[standard]
+streamlit_extras


### PR DESCRIPTION
Reference doc: https://discuss.streamlit.io/t/st-code-on-multiple-lines/50511

Add CSS style to allow the code to be wrapped, this enables directly previewing the entire token and makes it easier to copy because the copy button will not be mixed with the token string.

Used CSS properties:

- `white-space`: used for override the settings of `streamlit`, see https://discuss.streamlit.io/t/st-code-on-multiple-lines/50511
- [`hyphens`](https://developer.mozilla.org/docs/Web/CSS/hyphens): remove the auto inserted hyphen between non-space-breaking characters.
- [`overflow-wrap`](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap): always break the line if the line is going to be overflowed.

### Tests

The token is randomly generated (the length  of it is the same as the token generated by aliyundrive API)

#### Before

![截图_2024-04-12_20-56-17](https://github.com/messense/aliyundrive-webdav/assets/15844309/b39bdfa5-4376-4f71-96e4-7aa96b26a540)

#### After

![截图_2024-04-12_20-52-31](https://github.com/messense/aliyundrive-webdav/assets/15844309/408e51dd-4a6f-4b61-8cde-69b281fe7724)
